### PR TITLE
Added some very ugly deprecation warnings to some key files

### DIFF
--- a/lib/core/facets.rb
+++ b/lib/core/facets.rb
@@ -1,3 +1,10 @@
+unless $FACETS_LOADED
+  UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, \"require 'facets'\")", '2015-12-04') do
+    fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
+  end
+  $FACETS_LOADED = true
+end
+
 require 'facets/version.rb'
 
 require 'facets/array.rb'
@@ -38,4 +45,3 @@ require 'facets/symbol.rb'
 require 'facets/time.rb'
 require 'facets/to_hash.rb'
 require 'facets/unboundmethod.rb'
-

--- a/lib/core/facets.rb
+++ b/lib/core/facets.rb
@@ -1,8 +1,5 @@
-unless $FACETS_LOADED
-  UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, \"require 'facets'\")", '2015-12-04') do
-    fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
-  end
-  $FACETS_LOADED = true
+UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, \"require 'facets'\")", '2015-12-04') do
+  fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
 end
 
 require 'facets/version.rb'

--- a/lib/core/facets/string/camelcase.rb
+++ b/lib/core/facets/string/camelcase.rb
@@ -1,7 +1,5 @@
-unless $FACETS_LOADED
-  UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, 'facets/string/camelcase')", '2015-12-04') do
-    fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
-  end
+UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, 'facets/string/camelcase')", '2015-12-04') do
+  fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
 end
 
 class String

--- a/lib/core/facets/string/camelcase.rb
+++ b/lib/core/facets/string/camelcase.rb
@@ -1,3 +1,9 @@
+unless $FACETS_LOADED
+  UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, 'facets/string/camelcase')", '2015-12-04') do
+    fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
+  end
+end
+
 class String
 
   # Converts a string to camelcase. This method leaves the first character
@@ -70,4 +76,3 @@ class String
   end
 
 end
-

--- a/lib/core/facets/string/interpolate.rb
+++ b/lib/core/facets/string/interpolate.rb
@@ -1,7 +1,5 @@
-unless $FACETS_LOADED
-  UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, 'facets/string/interpolate')", '2015-12-04') do
-    fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
-  end
+UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, 'facets/string/interpolate')", '2015-12-04') do
+  fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
 end
 
 class String

--- a/lib/core/facets/string/interpolate.rb
+++ b/lib/core/facets/string/interpolate.rb
@@ -1,3 +1,9 @@
+unless $FACETS_LOADED
+  UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, 'facets/string/interpolate')", '2015-12-04') do
+    fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
+  end
+end
+
 class String
 
   # Interpolate. Provides a means of extenally using Ruby string
@@ -16,4 +22,3 @@ class String
   end
 
 end
-

--- a/lib/core/facets/string/snakecase.rb
+++ b/lib/core/facets/string/snakecase.rb
@@ -1,3 +1,9 @@
+unless $FACETS_LOADED
+  UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, 'facets/string/snakecase')", '2015-12-04') do
+    fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
+  end
+end
+
 class String
 
   # Underscore a string such that camelcase, dashes and spaces are
@@ -28,4 +34,3 @@ class String
   # TODO: Add *separators to #snakecase, like camelcase.
 
 end
-

--- a/lib/core/facets/string/snakecase.rb
+++ b/lib/core/facets/string/snakecase.rb
@@ -1,7 +1,5 @@
-unless $FACETS_LOADED
-  UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, 'facets/string/snakecase')", '2015-12-04') do
-    fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
-  end
+UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, 'facets/string/snakecase')", '2015-12-04') do
+  fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
 end
 
 class String


### PR DESCRIPTION
These files represent (to the best of my knowledge) some of our most common parts of the 'facets' gem. The idea: because it is known to cause conflicts with the `activesupport` gem (seen as late as today with @mriska and @tforsbacka), let us deprecate all of this as far as our platform is concerned, so we can get see where it is being used and eventually get rid of the whole thing, in a controlled manner.

Trust me: I know that global variables are bad. The idea here is to set a flag to avoid more warnings than is needed. I.e. if the user/an app is loading 'facets', we only need to produce a single warning for that - no need to warn multiple times. Maybe that's something we could live with, but... I'd rather not spend more time on this now since it's legacy cruft (from the perspective of our platform) so I don't think 100% pureness is needed in this case.

@jensnockert - you seem to be online. Care to dig out your review skills?
