### PR TITLE
Avoid issue with UxFactory.deprecate not always loaded

### DIFF
--- a/lib/core/facets.rb
+++ b/lib/core/facets.rb
@@ -1,6 +1,6 @@
 UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, \"require 'facets'\")", '2015-12-04') do
   fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
-end
+end if defined?(UxFactory) && UxFactory.respond_to?(:deprecated)
 
 require 'facets/version.rb'
 

--- a/lib/core/facets/string/camelcase.rb
+++ b/lib/core/facets/string/camelcase.rb
@@ -1,6 +1,6 @@
 UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, 'facets/string/camelcase')", '2015-12-04') do
   fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
-end
+end if defined?(UxFactory) && UxFactory.respond_to?(:deprecated)
 
 class String
 

--- a/lib/core/facets/string/interpolate.rb
+++ b/lib/core/facets/string/interpolate.rb
@@ -1,6 +1,6 @@
 UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, 'facets/string/interpolate')", '2015-12-04') do
   fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
-end
+end if defined?(UxFactory) && UxFactory.respond_to?(:deprecated)
 
 class String
 

--- a/lib/core/facets/string/snakecase.rb
+++ b/lib/core/facets/string/snakecase.rb
@@ -1,6 +1,6 @@
 UxFactory.deprecated(:require_facets, "Code that requires the 'facets' gem (more specifically, 'facets/string/snakecase')", '2015-12-04') do
   fail "Do not require the 'facets' gem. Rewrite the code to rely on the 'activesupport' gem instead."
-end
+end if defined?(UxFactory) && UxFactory.respond_to?(:deprecated)
 
 class String
 


### PR DESCRIPTION
This allows the code in this UxFactory-improved distribution of this gem to load outside of UxFactory Server.

Question to ponder: When the requires pass, what do we want the code to do, if anything?
## Current situation:

Bundler says "I can find more than one `facets` in the listed `source`s in my Gemfile. I can't decide which one is right!" 
## Workaround

So, the author of the app's Gemfile has to make a choice, telling Bundler from whence to get the facets gem. The facets is perhaps a dependency on some code they have in their Gemfile, so the Gemfile author adds a line:

``` ruby
gem 'facets', '~> 2.9', source: 'https://rubygems.org'
```
- if the user picks the one in ecraft's private gems, they lose because UxFactory constant may not be defined, and they get an error when loading that gem
- if the user picks the one in Rubygems, they get no errors
